### PR TITLE
docs: fix validation include line numbers

### DIFF
--- a/doc/validation.rst
+++ b/doc/validation.rst
@@ -64,4 +64,4 @@ a more detailed message. For example::
 The full mapping of validation checks is given below.
 
 .. literalinclude:: ../numpydoc/validate.py
-   :lines: 36-90
+   :lines: 37-93


### PR DESCRIPTION
A small PR to fix the line numbers being included from the `validate.py` file. (currently `ERROR_MSGS` is not showing up properly on the docs)